### PR TITLE
feat(ui): Make title size adjustable

### DIFF
--- a/components/Preview.tsx
+++ b/components/Preview.tsx
@@ -14,6 +14,7 @@ import FooterDropdown from "./FooterDropdown";
 import RoguebricksSVG from "./ui/roguebricks-svg";
 import { Button } from "./ui/button";
 import { ImagePlus } from "lucide-react";
+import TitleSizeDropdown from "./TitleSizeDropdown";
 
 const latoBold = Lato({ subsets: ["latin-ext"], weight: "700" });
 const lato = Lato({ subsets: ["latin-ext"], weight: "400" });
@@ -38,6 +39,7 @@ export default function Preview(props: PreviewProps) {
   const [footerImage, setFooterImage] = React.useState<File | null>(null);
   const [avatarImage, setAvatarImage] = React.useState<File | null>(null);
   const [hoversAvatar, setHoversAvatar] = React.useState<boolean>(false);
+  const [titleSize, setTitleSize] = React.useState<4.5 | 3.5 | 2.5>(4.5);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
@@ -73,11 +75,13 @@ export default function Preview(props: PreviewProps) {
         id="preview-content"
         className="flex flex-col w-[874px] h-[1240px] text-center bg-transparent text-black pt-4"
       >
+        <TitleSizeDropdown titleSize={titleSize} setTitleSize={setTitleSize} />
         <input
           type="text"
           id="mocName"
           placeholder="MOC title"
-          className={`mx-auto w-4/5 h-[196px] text-7xl text-center uppercase ${latoBold.className}`}
+          className={`mx-auto w-4/5 h-[196px] text-center uppercase ${latoBold.className}`}
+          style={{ fontSize: `${titleSize}rem` }}
         ></input>
 
         <div

--- a/components/Preview.tsx
+++ b/components/Preview.tsx
@@ -39,7 +39,7 @@ export default function Preview(props: PreviewProps) {
   const [footerImage, setFooterImage] = React.useState<File | null>(null);
   const [avatarImage, setAvatarImage] = React.useState<File | null>(null);
   const [hoversAvatar, setHoversAvatar] = React.useState<boolean>(false);
-  const [titleSize, setTitleSize] = React.useState<4.5 | 3.5 | 2.5>(4.5);
+  const [titleSize, setTitleSize] = React.useState<4.5 | 3.5 | 2.5 | 2>(4.5);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/components/TitleSizeDropdown.tsx
+++ b/components/TitleSizeDropdown.tsx
@@ -1,0 +1,64 @@
+import { ALargeSmall } from "lucide-react";
+import { Button } from "./ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
+
+type TitleSizeDropdownProps = {
+  titleSize: 4.5 | 3.5 | 2.5;
+  setTitleSize: (size: 4.5 | 3.5 | 2.5) => void;
+};
+
+export default function TitleSizeDropdown(props: TitleSizeDropdownProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          className="no-render absolute top-0 right-0 m-2 border-none"
+          variant="default"
+        >
+          <ALargeSmall className="mr-2" />
+          Title font size
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
+        <DropdownMenuCheckboxItem
+          checked={props.titleSize == 4.5}
+          onCheckedChange={() => {
+            if (props.titleSize != 4.5) {
+              props.setTitleSize(4.5);
+            }
+          }}
+          className="text-black"
+        >
+          large
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={props.titleSize == 3.5}
+          onCheckedChange={() => {
+            if (props.titleSize != 3.5) {
+              props.setTitleSize(3.5);
+            }
+          }}
+          className="text-black"
+        >
+          medium
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={props.titleSize == 2.5}
+          onCheckedChange={() => {
+            if (props.titleSize != 2.5) {
+              props.setTitleSize(2.5);
+            }
+          }}
+          className="text-black"
+        >
+          small
+        </DropdownMenuCheckboxItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/components/TitleSizeDropdown.tsx
+++ b/components/TitleSizeDropdown.tsx
@@ -8,8 +8,8 @@ import {
 } from "./ui/dropdown-menu";
 
 type TitleSizeDropdownProps = {
-  titleSize: 4.5 | 3.5 | 2.5;
-  setTitleSize: (size: 4.5 | 3.5 | 2.5) => void;
+  titleSize: 4.5 | 3.5 | 2.5 | 2;
+  setTitleSize: (size: 4.5 | 3.5 | 2.5 | 2) => void;
 };
 
 export default function TitleSizeDropdown(props: TitleSizeDropdownProps) {
@@ -57,6 +57,17 @@ export default function TitleSizeDropdown(props: TitleSizeDropdownProps) {
           className="text-black"
         >
           small
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={props.titleSize == 2}
+          onCheckedChange={() => {
+            if (props.titleSize != 2) {
+              props.setTitleSize(2);
+            }
+          }}
+          className="text-black"
+        >
+          tiny
         </DropdownMenuCheckboxItem>
       </DropdownMenuContent>
     </DropdownMenu>


### PR DESCRIPTION
The title size can now be set to one of three sizes via a dropdown menu:

- large (`4.5rem`)
- medium (`3.5rem`)
- small (`2.5rem`)